### PR TITLE
fix: render embed record text on feed api calls

### DIFF
--- a/src/routes/api/getCustomFeed/+server.ts
+++ b/src/routes/api/getCustomFeed/+server.ts
@@ -1,5 +1,6 @@
 import { renderTextToMarkdownToHTML } from "$lib/utils";
 import { error, json, type RequestHandler } from "@sveltejs/kit";
+import { AppBskyEmbedRecord, AppBskyEmbedRecordWithMedia, AppBskyFeedDefs, AppBskyGraphDefs, AtpBaseClient } from "@atproto/api";
 
 // Given a feed URI, cursor (?), and limit (opt)
 // Return a JSON of FeedViewPost
@@ -22,6 +23,19 @@ export const GET: RequestHandler = async ({ url, locals }) => {
   for (const post of data.feed) {
     // @ts-ignore
     post.html = await renderTextToMarkdownToHTML(post.post.record.text, locals.agent);
+
+    if (post.post.embed && AppBskyEmbedRecord.isView(post.post.embed) && !(
+      AppBskyGraphDefs.isListView(post.post.embed)
+      && AppBskyGraphDefs.isStarterPackViewBasic(post.post.embed)
+      && AppBskyFeedDefs.isGeneratorView(post.post.embed)
+    )) {
+      // @ts-ignore
+      post.post.embed.record.html = await renderTextToMarkdownToHTML(post.post.embed.record.value.text, agent);
+    }
+    else if (AppBskyEmbedRecordWithMedia.isView(post.post.embed)) {
+      // @ts-ignore
+      post.post.embed.record.record.html = await renderTextToMarkdownToHTML(post.post.embed.record.record.value.text, agent);
+    }
   }
 
   return json({ feed: data.feed, nextCursor: data.cursor });

--- a/src/routes/api/getFollowingFeed/+server.ts
+++ b/src/routes/api/getFollowingFeed/+server.ts
@@ -1,6 +1,6 @@
 import { renderTextToMarkdownToHTML } from "$lib/utils";
-import { AtpBaseClient } from "@atproto/api";
 import { error, json, type RequestHandler } from "@sveltejs/kit";
+import { AppBskyEmbedRecord, AppBskyEmbedRecordWithMedia, AppBskyFeedDefs, AppBskyGraphDefs, AtpBaseClient } from "@atproto/api";
 
 // Given a cursor and limit (opt)
 // Return a JSON of FeedViewPost
@@ -19,6 +19,19 @@ export const GET: RequestHandler = async ({ url, locals }) => {
   for (const post of data.feed) {
     // @ts-ignore
     post.html = await renderTextToMarkdownToHTML(post.post.record.text, locals.agent);
+
+    if (post.post.embed && AppBskyEmbedRecord.isView(post.post.embed) && !(
+      AppBskyGraphDefs.isListView(post.post.embed)
+      && AppBskyGraphDefs.isStarterPackViewBasic(post.post.embed)
+      && AppBskyFeedDefs.isGeneratorView(post.post.embed)
+    )) {
+      // @ts-ignore
+      post.post.embed.record.html = await renderTextToMarkdownToHTML(post.post.embed.record.value.text, agent);
+    }
+    else if (AppBskyEmbedRecordWithMedia.isView(post.post.embed)) {
+      // @ts-ignore
+      post.post.embed.record.record.html = await renderTextToMarkdownToHTML(post.post.embed.record.record.value.text, agent);
+    }
   }
 
   return json({ feed: data.feed, nextCursor: data.cursor });


### PR DESCRIPTION
Implement `renderTextToMarkdownToHTML` functions when getting posts from the `/api/getCustomFeed` and `/api/getFollowingFeed` endpoints.

Closes #18 