### PR TITLE
feat: toggle likes & reposts on posts

### DIFF
--- a/src/lib/components/PostItem.svelte
+++ b/src/lib/components/PostItem.svelte
@@ -13,9 +13,14 @@
   let { data, isBordered = false }: { data: FeedViewPost, isBordered?: boolean } = $props();
   const user = $page.data.user;
   const bookmarks = $page.data.bookmarks as Set<string>; 
-  let likes = $state(data.post.likeCount ?? 0);
-  let likeUri = $state(data.post.viewer?.like ?? undefined);
   let isBookmarked = $state(bookmarks.has(data.post.uri) ?? false);
+
+  let likes = $state(data.post.likeCount ?? 0);
+  let likeUri = $state(data.post.viewer?.like ?? "");
+
+  let reposts = $state(data.post.repostCount ?? 0);
+  let repostUri = $state(data.post.viewer?.repost ?? "");
+
   const record_id = data.post.uri.split("/").at(data.post.uri.split("/").length - 1);
 </script>
 
@@ -151,20 +156,52 @@
         </form>
       {/if}
     </div>
-    <button onclick={toastComingSoon} class="flex gap-1">
-      <Icon icon="iconamoon:comment" class="size-6" />
-      {data.post.replyCount}
-    </button>
-    <button onclick={toastComingSoon} class="flex gap-1">
-      <Icon icon="bx:repost" class="size-6" />
-      {data.post.quoteCount}
-    </button>
+
     {#if !user}
+      <button onclick={toastComingSoon} class="flex gap-1">
+        <Icon icon="iconamoon:comment" class="size-6" />
+        {data.post.replyCount}
+      </button>
+      <button onclick={toastComingSoon} class="flex gap-1">
+        <Icon icon="bx:repost" class="size-6" />
+        {reposts}
+      </button>
       <button onclick={() => toastError("Must be logged in to like")} class="flex gap-1">
         <Icon icon="prime:heart" class="size-6" />
-        {data.post.likeCount}
+        {likes}
       </button>
     {:else}
+      <button onclick={toastComingSoon} class="flex gap-1">
+        <Icon icon="iconamoon:comment" class="size-6" />
+        {data.post.replyCount}
+      </button>
+      <form 
+        method="POST" 
+        action="/?/toggleRepostPost" 
+        use:enhance={() => {
+            return async ({ result }) => {
+              // @ts-ignore
+              if (result.data.uri === data.post.uri) {
+                // @ts-ignore
+                repostUri = result.data.repostUri;
+                if (repostUri) { reposts++; }
+                else { reposts--; }
+              }
+              await applyAction(result);
+            }
+        }}
+      >
+        <input name="repost_uri" type="hidden" value={repostUri} />
+        <input name="post_uri" type="hidden" value={data.post.uri} />
+        <input name="post_cid" type="hidden" value={data.post.cid} />
+        <button type="submit" class="flex gap-1">
+          <Icon 
+            icon="bx:repost" 
+            class={`size-6 ${repostUri ? "text-green-500" : "text-white"}`} 
+          />
+          {reposts}
+        </button>
+      </form>
       <form 
         method="POST" 
         action="/?/toggleLikePost" 
@@ -185,7 +222,10 @@
         <input name="post_uri" type="hidden" value={data.post.uri} />
         <input name="post_cid" type="hidden" value={data.post.cid} />
         <button type="submit" class="flex gap-1">
-          <Icon icon={likeUri ? "prime:heart-fill" : "prime:heart"} class="size-6" />
+          <Icon 
+            icon={likeUri ? "prime:heart-fill" : "prime:heart"}
+            class={`size-6 ${likeUri ? "text-red-500" : "text-white"}`} 
+          />
           {likes}
         </button>
       </form>

--- a/src/lib/components/PostItem.svelte
+++ b/src/lib/components/PostItem.svelte
@@ -162,7 +162,7 @@
         <Icon icon="iconamoon:comment" class="size-6" />
         {data.post.replyCount}
       </button>
-      <button onclick={toastComingSoon} class="flex gap-1">
+      <button onclick={() => toastError("Must be logged in to repost")} class="flex gap-1">
         <Icon icon="bx:repost" class="size-6" />
         {reposts}
       </button>

--- a/src/routes/+page.server.ts
+++ b/src/routes/+page.server.ts
@@ -96,6 +96,24 @@ export const actions: Actions = {
       }
     }
   },
+  "toggleRepostPost": async ({ request, locals }) => {
+    const formData = await request.formData();
+    const repostUri = formData.get("repost_uri") as string;
+    const cid = formData.get("post_cid") as string;
+    const uri = formData.get("post_uri") as string;
+
+    const agent = locals.agent;
+    if (agent instanceof Agent) {
+      if (!repostUri) {
+        const { uri: newRepostUri } = await agent.repost(uri, cid);
+        return { message: "reposted", uri, repostUri: newRepostUri }
+      }
+      else {
+        await agent.deleteRepost(repostUri); 
+        return { message: "unrepost", uri, repostUri: "" }
+      }
+    }
+  },
   "bookmarkPost": async ({ request, locals }) => {
     if (!locals.user) {
       return fail(401); 

--- a/src/routes/+page.server.ts
+++ b/src/routes/+page.server.ts
@@ -78,19 +78,22 @@ export const actions: Actions = {
       return fail(500);
     }
   },
-  "likePost": async ({ request, locals }) => {
+  "toggleLikePost": async ({ request, locals }) => {
     const formData = await request.formData();
+    const likeUri = formData.get("like_uri") as string;
     const cid = formData.get("post_cid") as string;
     const uri = formData.get("post_uri") as string;
 
     const agent = locals.agent;
-    if (agent instanceof AtpBaseClient) {
-      return fail(401); 
-    }
-
     if (agent instanceof Agent) {
-      await agent.like(uri, cid);
-      return { success: true }
+      if (!likeUri) {
+        const { uri: newLikeUri } = await agent.like(uri, cid);
+        return { message: "liked", uri, likeUri: newLikeUri }
+      }
+      else {
+        await agent.deleteLike(likeUri); 
+        return { message: "unliked", uri, likeUri: "" }
+      }
     }
   },
   "bookmarkPost": async ({ request, locals }) => {

--- a/src/routes/p/[handle]/[record]/+page@.svelte
+++ b/src/routes/p/[handle]/[record]/+page@.svelte
@@ -9,8 +9,8 @@
   import Icon from '@iconify/svelte';
   import { applyAction, enhance } from '$app/forms';
   import { page } from '$app/stores';
-    import FeedTimeline from '$lib/components/FeedTimeline.svelte';
-    import Avatar from 'svelte-boring-avatars';
+  import FeedTimeline from '$lib/components/FeedTimeline.svelte';
+  import Avatar from 'svelte-boring-avatars';
 
   type Props = {
     data: {
@@ -35,7 +35,6 @@
     }
   });
 
-  $inspect($threadQuery);
   // @ts-ignore
   $effect(() => console.log($threadQuery.data.thread.parent?.post));
 </script>


### PR DESCRIPTION
Implement toggling of likes and reposts via the `PostItem` component and the `/p/<handle>/<record>` page, which progressively enhances the UI with color and number updates on click.


https://github.com/user-attachments/assets/991e9072-ab55-4932-9571-e2021dd6a1ab

