### PR TITLE
fix: disable autoplay for videos

### DIFF
--- a/src/lib/components/HlsPlayerEmbed.svelte
+++ b/src/lib/components/HlsPlayerEmbed.svelte
@@ -5,6 +5,6 @@
   let { embed }: { embed: AppBskyEmbedVideo.View } = $props();
 </script>
 
-<media-player title={embed.alt} src={embed.playlist} controls autoPlay muted>
+<media-player title={embed.alt} src={embed.playlist} controls>
   <media-provider></media-provider>
 </media-player>


### PR DESCRIPTION
Removed `autoplay` prop for `HlsPlayerEmbed`.